### PR TITLE
feat: template-driven Web UI with asset management (#4)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ google-api-python-client>=2.124.0
 python-jose[cryptography]>=3.3.0
 passlib[bcrypt]>=1.7.4
 python-multipart>=0.0.9
+jinja2>=3.1.0

--- a/src/usdagent/api.py
+++ b/src/usdagent/api.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import os
+import pathlib
 import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from fastapi import FastAPI, HTTPException, Depends
+from fastapi import FastAPI, HTTPException, Depends, Request
 from fastapi.responses import HTMLResponse
 from fastapi.security import OAuth2PasswordRequestForm
+from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
 
 from usdagent.usd_generator import generate_asset
@@ -19,6 +22,9 @@ app = FastAPI(
     description="USD Asset Generation API",
     version="0.1.0",
 )
+
+_templates_dir = pathlib.Path(__file__).parent / "templates"
+_templates = Jinja2Templates(directory=str(_templates_dir))
 
 
 # ---------------------------------------------------------------------------
@@ -183,62 +189,19 @@ async def auth_me(current_user: str = Depends(get_current_user)) -> dict[str, st
     return {"username": current_user}
 
 
+@app.get("/assets", response_model=list[AssetResponse])
+async def list_assets(_key: str = Depends(verify_api_key)) -> list[AssetResponse]:
+    """List all assets."""
+    return [AssetResponse(**record) for record in _assets.values()]
+
+
 @app.get("/ui", response_class=HTMLResponse)
-async def web_ui() -> str:
-    """Basic web UI for asset viewer and Google Drive export."""
-    # TODO: replace with proper template
-    return """<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>usdagent — USD Asset Viewer</title>
-  <style>
-    body { font-family: sans-serif; max-width: 800px; margin: 40px auto; padding: 0 20px; }
-    h1 { color: #333; }
-    #generate-form { margin: 20px 0; }
-    textarea { width: 100%; height: 100px; }
-    button { padding: 8px 16px; background: #0066cc; color: white; border: none; cursor: pointer; }
-    #result { margin-top: 20px; padding: 10px; background: #f0f0f0; display: none; }
-  </style>
-</head>
-<body>
-  <h1>usdagent — USD Asset Viewer</h1>
-  <div id="generate-form">
-    <h2>Generate a USD Asset</h2>
-    <textarea id="description" placeholder="Describe your 3D asset..."></textarea>
-    <br><br>
-    <button onclick="generateAsset()">Generate</button>
-  </div>
-  <div id="result">
-    <h3>Result</h3>
-    <pre id="result-text"></pre>
-    <button onclick="exportToDrive()" style="background:#34a853">Export to Google Drive</button>
-  </div>
-  <script>
-    async function generateAsset() {
-      const desc = document.getElementById('description').value;
-      if (!desc) { alert('Please enter a description'); return; }
-      const resp = await fetch('/assets', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json', 'X-API-Key': 'demo'},
-        body: JSON.stringify({description: desc})
-      });
-      const data = await resp.json();
-      document.getElementById('result').style.display = 'block';
-      document.getElementById('result-text').textContent = JSON.stringify(data, null, 2);
-      pollStatus(data.id);
-    }
-    async function pollStatus(id) {
-      const resp = await fetch('/assets/' + id, {headers: {'X-API-Key': 'demo'}});
-      const data = await resp.json();
-      document.getElementById('result-text').textContent = JSON.stringify(data, null, 2);
-      if (data.status === 'pending' || data.status === 'generating') {
-        setTimeout(() => pollStatus(id), 2000);
-      }
-    }
-    function exportToDrive() {
-      window.location.href = '/auth/google?next=' + encodeURIComponent(window.location.href);
-    }
-  </script>
-</body>
-</html>"""
+async def web_ui(request: Request) -> HTMLResponse:
+    """Web UI for asset management."""
+    google_configured = bool(os.environ.get("GOOGLE_CLIENT_ID"))
+    return _templates.TemplateResponse(
+        "ui.html",
+        {"request": request, "google_configured": google_configured},
+    )
+
+

--- a/src/usdagent/api.py
+++ b/src/usdagent/api.py
@@ -6,11 +6,13 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from fastapi import FastAPI, HTTPException, Header
+from fastapi import FastAPI, HTTPException, Depends
 from fastapi.responses import HTMLResponse
+from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel
 
 from usdagent.usd_generator import generate_asset
+from usdagent.auth import verify_api_key, get_current_user, authenticate_user, _create_access_token
 
 app = FastAPI(
     title="usdagent",
@@ -75,7 +77,7 @@ async def health() -> dict[str, str]:
 @app.post("/assets", status_code=202, response_model=AssetResponse)
 async def create_asset(
     req: CreateAssetRequest,
-    x_api_key: str = Header(...),
+    _key: str = Depends(verify_api_key),
 ) -> AssetResponse:
     """Create a new USD asset from a text description."""
     # TODO: validate API key
@@ -110,7 +112,7 @@ async def create_asset(
 @app.get("/assets/{asset_id}", response_model=AssetResponse)
 async def get_asset(
     asset_id: str,
-    x_api_key: str = Header(...),
+    _key: str = Depends(verify_api_key),
 ) -> AssetResponse:
     """Retrieve an asset and its generation status."""
     # TODO: validate API key
@@ -124,7 +126,7 @@ async def get_asset(
 async def refine_asset(
     asset_id: str,
     req: RefineAssetRequest,
-    x_api_key: str = Header(...),
+    _key: str = Depends(verify_api_key),
 ) -> AssetResponse:
     """Iteratively refine an existing asset."""
     # TODO: validate API key
@@ -163,6 +165,22 @@ async def refine_asset(
         record["url"] = None
 
     return AssetResponse(**record)
+
+
+@app.post("/auth/token")
+async def login(form_data: OAuth2PasswordRequestForm = Depends()) -> dict[str, str]:
+    """Obtain a JWT access token."""
+    username = authenticate_user(form_data.username, form_data.password)
+    if not username:
+        raise HTTPException(status_code=401, detail="Incorrect username or password")
+    token = _create_access_token(username)
+    return {"access_token": token, "token_type": "bearer"}
+
+
+@app.get("/auth/me")
+async def auth_me(current_user: str = Depends(get_current_user)) -> dict[str, str]:
+    """Return info about the current authenticated user."""
+    return {"username": current_user}
 
 
 @app.get("/ui", response_class=HTMLResponse)

--- a/src/usdagent/auth.py
+++ b/src/usdagent/auth.py
@@ -1,0 +1,86 @@
+"""Authentication utilities for usdagent."""
+from __future__ import annotations
+
+import os
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Header, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+_JWT_SECRET = os.environ.get("USDAGENT_JWT_SECRET") or secrets.token_hex(32)
+_JWT_ALGORITHM = "HS256"
+_JWT_EXPIRE_MINUTES = 60
+
+_pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token")
+
+
+def _load_api_keys() -> set[str]:
+    raw = os.environ.get("USDAGENT_API_KEYS", "")
+    if not raw:
+        return set()
+    return {k.strip() for k in raw.split(",") if k.strip()}
+
+
+def _load_users() -> dict[str, str]:
+    """Return {username: hashed_password}."""
+    raw = os.environ.get("USDAGENT_USERS", "admin:changeme")
+    users: dict[str, str] = {}
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if ":" in entry:
+            username, password = entry.split(":", 1)
+            users[username.strip()] = _pwd_context.hash(password.strip())
+    return users
+
+
+def verify_api_key(x_api_key: str = Header(...)) -> str:
+    """FastAPI dependency — validates X-API-Key header."""
+    keys = _load_api_keys()
+    if not keys:
+        # No keys configured — open/dev mode, accept any key
+        return x_api_key
+    if x_api_key in keys:
+        return x_api_key
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid API key",
+    )
+
+
+def _create_access_token(username: str) -> str:
+    expire = datetime.now(tz=timezone.utc) + timedelta(minutes=_JWT_EXPIRE_MINUTES)
+    payload = {"sub": username, "exp": expire}
+    return jwt.encode(payload, _JWT_SECRET, algorithm=_JWT_ALGORITHM)
+
+
+def authenticate_user(username: str, password: str) -> str | None:
+    """Return username if credentials are valid, else None."""
+    users = _load_users()
+    hashed = users.get(username)
+    if hashed is None:
+        return None
+    if not _pwd_context.verify(password, hashed):
+        return None
+    return username
+
+
+def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]) -> str:
+    """FastAPI dependency — validates Bearer token, returns username."""
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, _JWT_SECRET, algorithms=[_JWT_ALGORITHM])
+        username: str | None = payload.get("sub")
+        if username is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+    return username

--- a/src/usdagent/templates/ui.html
+++ b/src/usdagent/templates/ui.html
@@ -1,0 +1,412 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>usdagent — USD Asset Studio</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen">
+
+<!-- Login Modal -->
+<div id="login-modal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 hidden">
+  <div class="bg-white rounded-lg shadow-xl p-8 w-full max-w-md">
+    <h2 class="text-2xl font-bold text-gray-800 mb-6">Sign In</h2>
+    <div id="login-error" class="hidden mb-4 p-3 bg-red-100 text-red-700 rounded"></div>
+    <div class="space-y-4">
+      <div>
+        <label class="block text-sm font-medium text-gray-700 mb-1">Username</label>
+        <input id="login-username" type="text" class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" placeholder="admin">
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gray-700 mb-1">Password</label>
+        <input id="login-password" type="password" class="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" placeholder="changeme">
+      </div>
+      <button onclick="doLogin()" class="w-full bg-blue-600 text-white py-2 rounded font-medium hover:bg-blue-700 transition">Sign In</button>
+    </div>
+  </div>
+</div>
+
+<!-- Header -->
+<header class="bg-white shadow-sm">
+  <div class="max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
+    <h1 class="text-2xl font-bold text-gray-900">usdagent</h1>
+    <div class="flex items-center gap-4">
+      <span id="user-badge" class="hidden text-sm text-gray-600"></span>
+      <button onclick="logout()" id="logout-btn" class="hidden text-sm text-red-600 hover:underline">Sign out</button>
+    </div>
+  </div>
+</header>
+
+<main class="max-w-7xl mx-auto px-4 py-8">
+  <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+
+    <!-- Left: Generate + Refine -->
+    <div class="lg:col-span-1 space-y-6">
+
+      <!-- Generate Form -->
+      <div class="bg-white rounded-lg shadow p-6">
+        <h2 class="text-lg font-semibold text-gray-800 mb-4">Generate Asset</h2>
+        <div class="space-y-4">
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">Description</label>
+            <textarea id="gen-description" rows="4" class="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" placeholder="Describe your 3D asset (e.g. 'a large blue sphere')"></textarea>
+          </div>
+          <div class="grid grid-cols-3 gap-2">
+            <div>
+              <label class="block text-xs font-medium text-gray-600 mb-1">Scale</label>
+              <input id="gen-scale" type="number" value="1.0" step="0.1" min="0.1" class="w-full border border-gray-300 rounded px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-gray-600 mb-1">Up Axis</label>
+              <select id="gen-up-axis" class="w-full border border-gray-300 rounded px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                <option value="Y" selected>Y</option>
+                <option value="Z">Z</option>
+                <option value="X">X</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-gray-600 mb-1">Units</label>
+              <select id="gen-units" class="w-full border border-gray-300 rounded px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                <option value="centimeters" selected>cm</option>
+                <option value="meters">m</option>
+                <option value="millimeters">mm</option>
+                <option value="inches">in</option>
+                <option value="feet">ft</option>
+              </select>
+            </div>
+          </div>
+          <button onclick="generateAsset()" id="gen-btn" class="w-full bg-blue-600 text-white py-2 rounded font-medium hover:bg-blue-700 transition flex items-center justify-center gap-2">
+            <span>Generate</span>
+            <span id="gen-spinner" class="hidden">...</span>
+          </button>
+        </div>
+      </div>
+
+      <!-- Refine Panel -->
+      <div id="refine-panel" class="bg-white rounded-lg shadow p-6 hidden">
+        <h2 class="text-lg font-semibold text-gray-800 mb-4">Refine Asset</h2>
+        <p class="text-xs text-gray-500 mb-3">Refining: <span id="refine-asset-id" class="font-mono text-gray-700"></span></p>
+        <div class="space-y-3">
+          <textarea id="refine-feedback" rows="3" class="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" placeholder="Describe changes (e.g. 'make it twice as large and red')"></textarea>
+          <button onclick="refineAsset()" class="w-full bg-purple-600 text-white py-2 rounded font-medium hover:bg-purple-700 transition">Refine</button>
+        </div>
+      </div>
+
+    </div>
+
+    <!-- Middle: Asset List -->
+    <div class="lg:col-span-1">
+      <div class="bg-white rounded-lg shadow p-6">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-lg font-semibold text-gray-800">Assets</h2>
+          <button onclick="loadAssets()" class="text-sm text-blue-600 hover:underline">Refresh</button>
+        </div>
+        <div id="asset-list" class="space-y-2 max-h-[600px] overflow-y-auto">
+          <p class="text-sm text-gray-400 text-center py-4">No assets yet. Generate one!</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Right: Asset Detail -->
+    <div class="lg:col-span-1">
+      <div id="asset-detail" class="bg-white rounded-lg shadow p-6 hidden">
+        <h2 class="text-lg font-semibold text-gray-800 mb-4">Asset Detail</h2>
+        <div class="space-y-3">
+          <div>
+            <span class="text-xs font-medium text-gray-500">ID</span>
+            <p id="detail-id" class="font-mono text-xs text-gray-800 break-all"></p>
+          </div>
+          <div>
+            <span class="text-xs font-medium text-gray-500">Status</span>
+            <p id="detail-status"></p>
+          </div>
+          <div>
+            <span class="text-xs font-medium text-gray-500">Description</span>
+            <p id="detail-description" class="text-sm text-gray-700"></p>
+          </div>
+          <div>
+            <span class="text-xs font-medium text-gray-500">Created</span>
+            <p id="detail-created" class="text-sm text-gray-700"></p>
+          </div>
+          <div id="detail-completed-row" class="hidden">
+            <span class="text-xs font-medium text-gray-500">Completed</span>
+            <p id="detail-completed" class="text-sm text-gray-700"></p>
+          </div>
+          <div id="detail-parent-row" class="hidden">
+            <span class="text-xs font-medium text-gray-500">Refined From</span>
+            <p id="detail-parent" class="font-mono text-xs text-gray-700"></p>
+          </div>
+          <div id="detail-actions" class="hidden space-y-2 pt-2 border-t border-gray-100">
+            <a id="detail-download" href="#" download class="block w-full text-center bg-green-600 text-white py-2 rounded font-medium hover:bg-green-700 transition text-sm">
+              Download .usda
+            </a>
+            <button onclick="openRefinePanel()" class="w-full bg-purple-600 text-white py-2 rounded font-medium hover:bg-purple-700 transition text-sm">
+              Refine This Asset
+            </button>
+            <button id="drive-btn" onclick="exportToDrive()" class="w-full bg-emerald-600 text-white py-2 rounded font-medium hover:bg-emerald-700 transition text-sm">
+              Export to Google Drive
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</main>
+
+<script>
+  let currentAssetId = null;
+  let apiKey = 'demo';
+
+  function getToken() { return localStorage.getItem('usdagent_token'); }
+  function setToken(t) { localStorage.setItem('usdagent_token', t); }
+  function clearToken() { localStorage.removeItem('usdagent_token'); }
+
+  function authHeaders() {
+    const token = getToken();
+    const headers = { 'Content-Type': 'application/json' };
+    if (token) headers['Authorization'] = 'Bearer ' + token;
+    headers['X-API-Key'] = apiKey;
+    return headers;
+  }
+
+  async function apiFetch(url, options = {}) {
+    options.headers = { ...authHeaders(), ...(options.headers || {}) };
+    const resp = await fetch(url, options);
+    if (resp.status === 401) {
+      showLoginModal();
+      throw new Error('Unauthorized');
+    }
+    return resp;
+  }
+
+  function showLoginModal() {
+    document.getElementById('login-modal').classList.remove('hidden');
+  }
+  function hideLoginModal() {
+    document.getElementById('login-modal').classList.add('hidden');
+  }
+
+  async function doLogin() {
+    const username = document.getElementById('login-username').value;
+    const password = document.getElementById('login-password').value;
+    const errEl = document.getElementById('login-error');
+    errEl.classList.add('hidden');
+
+    const resp = await fetch('/auth/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ username, password }),
+    });
+    if (!resp.ok) {
+      errEl.textContent = 'Invalid credentials. Please try again.';
+      errEl.classList.remove('hidden');
+      return;
+    }
+    const data = await resp.json();
+    setToken(data.access_token);
+    hideLoginModal();
+    updateUserBadge();
+    loadAssets();
+  }
+
+  function logout() {
+    clearToken();
+    document.getElementById('user-badge').classList.add('hidden');
+    document.getElementById('logout-btn').classList.add('hidden');
+  }
+
+  async function updateUserBadge() {
+    const token = getToken();
+    if (!token) return;
+    try {
+      const resp = await fetch('/auth/me', { headers: { Authorization: 'Bearer ' + token } });
+      if (resp.ok) {
+        const data = await resp.json();
+        const badge = document.getElementById('user-badge');
+        badge.textContent = 'Signed in as ' + data.username;
+        badge.classList.remove('hidden');
+        document.getElementById('logout-btn').classList.remove('hidden');
+      }
+    } catch (_) {}
+  }
+
+  function statusBadge(status) {
+    const colors = {
+      ready: 'bg-green-100 text-green-800',
+      generating: 'bg-yellow-100 text-yellow-800',
+      pending: 'bg-blue-100 text-blue-800',
+      error: 'bg-red-100 text-red-800',
+    };
+    const cls = colors[status] || 'bg-gray-100 text-gray-800';
+    return `<span class="px-2 py-0.5 rounded text-xs font-medium ${cls}">${status}</span>`;
+  }
+
+  async function loadAssets() {
+    try {
+      const resp = await apiFetch('/assets');
+      if (!resp.ok) return;
+      const assets = await resp.json();
+      renderAssetList(assets);
+    } catch (_) {}
+  }
+
+  function renderAssetList(assets) {
+    const el = document.getElementById('asset-list');
+    if (!assets.length) {
+      el.innerHTML = '<p class="text-sm text-gray-400 text-center py-4">No assets yet. Generate one!</p>';
+      return;
+    }
+    el.innerHTML = assets.slice().reverse().map(a => `
+      <div onclick="selectAsset('${a.id}')" class="cursor-pointer p-3 rounded border border-gray-200 hover:bg-gray-50 transition ${a.id === currentAssetId ? 'bg-blue-50 border-blue-300' : ''}">
+        <div class="flex items-center justify-between mb-1">
+          ${statusBadge(a.status)}
+          <span class="text-xs text-gray-400">${new Date(a.created_at).toLocaleTimeString()}</span>
+        </div>
+        <p class="text-sm text-gray-700 truncate">${a.description || '(no description)'}</p>
+        <p class="text-xs font-mono text-gray-400 truncate">${a.id}</p>
+      </div>
+    `).join('');
+  }
+
+  async function selectAsset(id) {
+    currentAssetId = id;
+    try {
+      const resp = await apiFetch('/assets/' + id);
+      if (!resp.ok) return;
+      const asset = await resp.json();
+      showAssetDetail(asset);
+      loadAssets(); // refresh list to update selection highlight
+    } catch (_) {}
+  }
+
+  function showAssetDetail(asset) {
+    document.getElementById('asset-detail').classList.remove('hidden');
+    document.getElementById('detail-id').textContent = asset.id;
+    document.getElementById('detail-status').innerHTML = statusBadge(asset.status);
+    document.getElementById('detail-description').textContent = asset.description || '—';
+    document.getElementById('detail-created').textContent = new Date(asset.created_at).toLocaleString();
+
+    if (asset.completed_at) {
+      document.getElementById('detail-completed').textContent = new Date(asset.completed_at).toLocaleString();
+      document.getElementById('detail-completed-row').classList.remove('hidden');
+    } else {
+      document.getElementById('detail-completed-row').classList.add('hidden');
+    }
+
+    if (asset.parent_id) {
+      document.getElementById('detail-parent').textContent = asset.parent_id;
+      document.getElementById('detail-parent-row').classList.remove('hidden');
+    } else {
+      document.getElementById('detail-parent-row').classList.add('hidden');
+    }
+
+    if (asset.status === 'ready') {
+      document.getElementById('detail-actions').classList.remove('hidden');
+      if (asset.url) {
+        document.getElementById('detail-download').href = '/assets/' + asset.id + '/download';
+        document.getElementById('detail-download').setAttribute('download', asset.id + '.usda');
+      }
+    } else {
+      document.getElementById('detail-actions').classList.add('hidden');
+    }
+
+    // Check if Drive is configured
+    checkDriveConfigured();
+  }
+
+  async function checkDriveConfigured() {
+    const btn = document.getElementById('drive-btn');
+    if (!btn) return;
+    // Attempt a drive check; if GOOGLE_CLIENT_ID not set, backend returns 501
+    // We just leave button enabled and handle gracefully on click
+  }
+
+  async function generateAsset() {
+    const description = document.getElementById('gen-description').value.trim();
+    if (!description) { alert('Please enter a description.'); return; }
+    const scale = parseFloat(document.getElementById('gen-scale').value) || 1.0;
+    const up_axis = document.getElementById('gen-up-axis').value;
+    const units = document.getElementById('gen-units').value;
+
+    const btn = document.getElementById('gen-btn');
+    const spinner = document.getElementById('gen-spinner');
+    btn.disabled = true;
+    spinner.classList.remove('hidden');
+
+    try {
+      const resp = await apiFetch('/assets', {
+        method: 'POST',
+        body: JSON.stringify({ description, options: { scale, up_axis, units } }),
+      });
+      if (!resp.ok) { alert('Failed to generate asset.'); return; }
+      const asset = await resp.json();
+      currentAssetId = asset.id;
+      showAssetDetail(asset);
+      loadAssets();
+    } catch (_) {
+    } finally {
+      btn.disabled = false;
+      spinner.classList.add('hidden');
+    }
+  }
+
+  function openRefinePanel() {
+    if (!currentAssetId) return;
+    document.getElementById('refine-panel').classList.remove('hidden');
+    document.getElementById('refine-asset-id').textContent = currentAssetId;
+    document.getElementById('refine-feedback').focus();
+  }
+
+  async function refineAsset() {
+    const feedback = document.getElementById('refine-feedback').value.trim();
+    if (!feedback) { alert('Please enter refinement feedback.'); return; }
+    if (!currentAssetId) return;
+
+    try {
+      const resp = await apiFetch('/assets/' + currentAssetId + '/refine', {
+        method: 'PATCH',
+        body: JSON.stringify({ feedback }),
+      });
+      if (!resp.ok) { alert('Failed to refine asset.'); return; }
+      const asset = await resp.json();
+      currentAssetId = asset.id;
+      document.getElementById('refine-panel').classList.add('hidden');
+      document.getElementById('refine-feedback').value = '';
+      showAssetDetail(asset);
+      loadAssets();
+    } catch (_) {}
+  }
+
+  async function exportToDrive() {
+    if (!currentAssetId) return;
+    // First try the drive export endpoint
+    try {
+      const resp = await apiFetch('/assets/' + currentAssetId + '/export/drive', { method: 'POST' });
+      if (resp.status === 501) {
+        alert('Google Drive is not configured. Set GOOGLE_CLIENT_ID to enable Drive integration.');
+        return;
+      }
+      if (resp.status === 401 || resp.status === 403) {
+        // Need Google auth — redirect
+        window.location.href = '/auth/google?next=' + encodeURIComponent(window.location.href);
+        return;
+      }
+      if (resp.ok) {
+        const data = await resp.json();
+        alert('Exported to Google Drive: ' + (data.file_id || 'success'));
+      } else {
+        alert('Export failed.');
+      }
+    } catch (_) {
+      alert('Export failed.');
+    }
+  }
+
+  // Init
+  updateUserBadge();
+  loadAssets();
+</script>
+</body>
+</html>

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,72 @@
+"""Tests for authentication (JWT + API key validation)."""
+from __future__ import annotations
+
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def set_api_keys(monkeypatch):
+    monkeypatch.setenv("USDAGENT_API_KEYS", "validkey,anotherkey")
+    monkeypatch.setenv("USDAGENT_USERS", "testuser:testpass")
+
+
+@pytest.fixture()
+def client():
+    # Import after env vars are patched
+    from src.usdagent.api import app
+    return TestClient(app)
+
+
+def test_valid_api_key_accepted(client):
+    resp = client.get("/assets/nonexistent", headers={"X-API-Key": "validkey"})
+    assert resp.status_code == 404  # asset not found, not 401
+
+
+def test_invalid_api_key_rejected(client):
+    resp = client.get("/assets/nonexistent", headers={"X-API-Key": "badkey"})
+    assert resp.status_code == 401
+
+
+def test_login_valid_credentials(client):
+    resp = client.post(
+        "/auth/token",
+        data={"username": "testuser", "password": "testpass"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "access_token" in data
+    assert data["token_type"] == "bearer"
+
+
+def test_login_invalid_credentials(client):
+    resp = client.post(
+        "/auth/token",
+        data={"username": "testuser", "password": "wrongpass"},
+    )
+    assert resp.status_code == 401
+
+
+def test_auth_me_with_valid_token(client):
+    # Get token
+    login_resp = client.post(
+        "/auth/token",
+        data={"username": "testuser", "password": "testpass"},
+    )
+    token = login_resp.json()["access_token"]
+
+    resp = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    assert resp.json()["username"] == "testuser"
+
+
+def test_auth_me_without_token(client):
+    resp = client.get("/auth/me")
+    assert resp.status_code == 401
+
+
+def test_auth_me_with_invalid_token(client):
+    resp = client.get("/auth/me", headers={"Authorization": "Bearer invalidtoken"})
+    assert resp.status_code == 401


### PR DESCRIPTION
Closes #4

> **Note:** This branch is based on `feature/auth` and depends on #5 being merged first.

## Summary
- Replace inline HTML stub with Jinja2-rendered `templates/ui.html`
- Full single-page app: generate form, asset list panel, asset detail view, refine panel
- Google Drive export button with graceful "not configured" fallback
- Auth: 401 triggers login modal, JWT stored in localStorage
- `GET /assets` endpoint to list all assets (API key protected)
- Tailwind CSS via CDN, vanilla JS with async/await

🤖 Generated with [Claude Code](https://claude.com/claude-code)